### PR TITLE
Added platform suffix to package name to distinguish them by platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ package:
 	find examples/asm -type f -name '*.bin' -delete
 	mv tmp/* bin/
 	rm -d tmp
-	rm -f huc-$(DATE).zip
-	zip -r huc-$(DATE) * -x *.zip -x .*
+	rm -f huc-$(DATE)-$(shell uname).zip
+	zip -r huc-$(DATE)-$(shell uname).zip * -x *.zip -x .*
 
 examples: src

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ check:
 	md5sum -c < examples/checksum.txt
 
 DATE = $(shell date +%F)
+ifneq ($(OS),Windows_NT)
+	PLATFORMSUFFIX = $(shell uname)
+else
+	PLATFORMSUFFIX = Win64
+endif
+
 
 package:
 	mkdir -p tmp
@@ -49,7 +55,7 @@ package:
 	find examples/asm -type f -name '*.bin' -delete
 	mv tmp/* bin/
 	rm -d tmp
-	rm -f huc-$(DATE)-$(shell uname).zip
-	zip -r huc-$(DATE)-$(shell uname).zip * -x *.zip -x .*
+	rm -f huc-$(DATE)-$(PLATFORMSUFFIX).zip
+	zip -r huc-$(DATE)-$(PLATFORMSUFFIX).zip * -x *.zip -x .*
 
 examples: src


### PR DESCRIPTION
Conversation starter to have a different package name per platform.

Package names will look like this using $shell uname (not super user-friendly, but works)
huc-2022-05-20-Darwin.zip
huc-2022-05-20-Linux.zip
huc-2022-05-20-MINGW64_NT-10.0-20348.zip 

Anything else I could use at the makefile level to have nicer names?

Also added an .zip explicit suffix, to make sure it's always present in the file name (win64 packages didn't have it)