### PR TITLE
Activated test (linux only for now), packaging and publication of the package as a GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
   publish_package:
     runs-on: ubuntu-latest
     needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04]
-    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3
@@ -196,9 +196,6 @@ jobs:
           name: package-ubuntu-20.04
         # https://github.com/pyTooling/Actions/tree/main/releaser
         # need to use composite on windows, since docker isn't available
-      - name: Debug step
-        run: |
-          echo ${{ github.ref_name }}
       - name: publish package
         uses: pyTooling/Actions/releaser@r0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
           name: toolchain-${{ matrix.os }}
           path: |
             bin
-            include
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx
@@ -82,7 +81,6 @@ jobs:
           name: toolchain-${{ matrix.os }}
           path: |
             bin
-            include
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx
@@ -104,7 +102,6 @@ jobs:
           name: toolchain-mingw64
           path: |
             bin
-            include
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - master  
+  # activating dispatch to allow manual runs
+  # workflow_dispatch:
 
 env:
   MSYS2_INSTALL_FOLDER: C:\msys64\ # provided by GitHub Actions VMs
@@ -174,8 +176,9 @@ jobs:
             *.zip
 
   publish_package:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04]
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3
@@ -194,10 +197,10 @@ jobs:
         # https://github.com/pyTooling/Actions/tree/main/releaser
         # need to use composite on windows, since docker isn't available
       - name: publish package
-        uses: pyTooling/Actions/releaser/composite@main
+        uses: pyTooling/Actions/releaser@r0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: latest
+          tag: ${{ github.ref_name }}
           rm: true # do not keep old latest artifacts
           files: |
             *.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - master
-  # activating dispatch to allow manual runs
-  workflow_dispatch:
 
 env:
   MSYS2_INSTALL_FOLDER: C:\msys64\ # provided by GitHub Actions VMs
@@ -35,6 +33,33 @@ jobs:
           path: |
             bin
             include
+            examples/**/*.iso
+            examples/**/*.pce
+            examples/**/*.sgx
+            src/huc/huc
+            tgemu/tgemu
+
+  test_linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    needs: build_linux
+    steps:
+      - name: Check out code from the repository
+        uses: actions/checkout@v3
+      - name: Get previoulsy built artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: toolchain-${{ matrix.os }}
+      - name: Test
+        run: |
+          chmod +x bin/* # Github Action artifacts don't keep exec flags https://github.com/actions/upload-artifact#permission-loss'
+          chmod +x src/huc/huc
+          chmod +x tgemu/tgemu
+          make check
+          make test
+          echo Test Complete
 
   build_mac:
     strategy:
@@ -56,6 +81,9 @@ jobs:
           path: |
             bin
             include
+            examples/**/*.iso
+            examples/**/*.pce
+            examples/**/*.sgx
 
   build_msys2_windows_2022:
     runs-on: windows-2022
@@ -74,4 +102,103 @@ jobs:
           path: |
             bin
             include
+            examples/**/*.iso
+            examples/**/*.pce
+            examples/**/*.sgx
+
+  package_msys2_windows_2022:
+    runs-on: windows-2022
+    needs: build_msys2_windows_2022
+    steps:
+      - name: Check out code from the repository
+        uses: actions/checkout@v3
+      - name: Get previoulsy built artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: toolchain-mingw64
+      - name: Package
+        run: |
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S mingw-w64-x86_64-binutils make git zip --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make package"
+          echo Package Complete
+        # https://github.com/pyTooling/Actions/tree/main/releaser
+        # need to use composite on windows, since docker isn't available
+      - name: Archive package
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-mingw64
+          path: |
+            *.zip
+
+  package_macos_12:
+    runs-on: macos-12
+    needs: build_mac
+    steps:
+      - name: Check out code from the repository
+        uses: actions/checkout@v3
+      - name: Get previoulsy built artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: toolchain-macos-12
+      - name: Package
+        run: |
+          brew install make # need gnumake
+          gmake package
+          echo Package Complete
+      - name: Archive package
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-macos-12
+          path: |
+            *.zip
+
+  package_ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    needs: build_linux
+    steps:
+      - name: Check out code from the repository
+        uses: actions/checkout@v3
+      - name: Get previoulsy built artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: toolchain-ubuntu-20.04
+      - name: Package
+        run: |
+          make package
+          echo Package Complete
+      - name: Archive package
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-ubuntu-20.04
+          path: |
+            *.zip
+
+  publish_package:
+    runs-on: windows-2022
+    needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04]
+    steps:
+      - name: Check out code from the repository
+        uses: actions/checkout@v3
+      - name: Get previoulsy built artifacts win64
+        uses: actions/download-artifact@v3
+        with:
+          name: package-mingw64
+      - name: Get previoulsy built artifacts macos
+        uses: actions/download-artifact@v3
+        with:
+          name: package-macos-12
+      - name: Get previoulsy built artifacts linux
+        uses: actions/download-artifact@v3
+        with:
+          name: package-ubuntu-20.04
+        # https://github.com/pyTooling/Actions/tree/main/releaser
+        # need to use composite on windows, since docker isn't available
+      - name: publish package
+        uses: pyTooling/Actions/releaser/composite@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: latest
+          rm: true # do not keep old latest artifacts
+          files: |
+            *.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx
+          if-no-files-found: error
 
   build_msys2_windows_2022:
     runs-on: windows-2022
@@ -107,6 +108,7 @@ jobs:
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx
+          if-no-files-found: error
 
   package_msys2_windows_2022:
     runs-on: windows-2022
@@ -131,6 +133,7 @@ jobs:
           name: package-mingw64
           path: |
             *.zip
+          if-no-files-found: error
 
   package_macos_12:
     runs-on: macos-12
@@ -153,6 +156,7 @@ jobs:
           name: package-macos-12
           path: |
             *.zip
+          if-no-files-found: error
 
   package_ubuntu-20-04:
     runs-on: ubuntu-20.04
@@ -174,6 +178,7 @@ jobs:
           name: package-ubuntu-20.04
           path: |
             *.zip
+          if-no-files-found: error
 
   publish_package:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,9 @@ jobs:
           name: package-ubuntu-20.04
         # https://github.com/pyTooling/Actions/tree/main/releaser
         # need to use composite on windows, since docker isn't available
+      - name: Debug step
+        run: |
+          echo ${{ github.ref_name }}
       - name: publish package
         uses: pyTooling/Actions/releaser@r0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
   publish_package:
     runs-on: ubuntu-latest
     needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04]
-    if: github.ref == 'refs/heads/master'
+    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   push:
   pull_request:
     branches:
-      - master  
+      - master
   # activating dispatch to allow manual runs
   # workflow_dispatch:
 


### PR DESCRIPTION
This is the initial activation of the CI part for test and packaging.
* Tests are run on Linux only for now
* Every platform will generate a zip package named huc-2022-05-21-<Platform>.zip, stored as a build artifact of the package step
* A fan-in step will be run in master only, to publish the various packages once everything is green, (either using the branch name, or an actual tag)
* Arbitrarily decided to use macos-12 and ubuntu-20.04 binaries to be added to the package.
* Enjoy automation :)