### PR TITLE
updated test script to support running on windows.

### DIFF
--- a/test/mk
+++ b/test/mk
@@ -7,6 +7,12 @@ test -z "$tests" && tests="tests/*.c dg/*.c"
 test -n "$1" && tests="$@"
 fails=0
 nocompiles=0
+exesuffix=
+
+if [[ "$OS" == "Windows_NT" ]]; then
+	exesuffix=.exe
+fi
+
 for d in large small norec noopt
 do
 	fails=0
@@ -20,14 +26,14 @@ do
 	for i in $tests
 	do
 		echo -en "$d\t$i: "
-		if ! ../src/huc/huc -DNO_LABEL_VALUES $opt $i -lmalloc >/dev/null ; then
+		if ! ../bin/huc${exesuffix} -DNO_LABEL_VALUES $opt $i -lmalloc >/dev/null ; then
 			echo NOCOMPILE
-			../src/huc/huc $opt $i
+			../bin/huc${exesuffix} $opt $i
 			exit
 			nocompiles=$((nocompiles + 1))
 			continue
 		fi
-		#if ../tgemu/tgemu "${i%.c}.pce" 2>/dev/null >/dev/null ; then
+		#if ../tgemu/tgemu${exesuffix} "${i%.c}.pce" 2>/dev/null >/dev/null ; then
 			echo PASS
 			passes=$((passes + 1))
 		#else


### PR DESCRIPTION
Tests seem to be properly working on windows as long as the exe name includes the .exe suffix.

* Added a test of the OS to add or not .exe when calling huc
* Using huc from the bin folder instead of the src version so only one version of huc needs to be stored by the build stage