### PR TITLE
Refactored the build flow to add testing on PC and Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Get previoulsy built artifacts
         uses: actions/download-artifact@v3
         with:
-          name: toolchain-mingw64
+          name: toolchain-windows-2022
       - name: Package
         run: |
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S mingw-w64-x86_64-binutils make git zip --noconfirm"
@@ -200,7 +200,7 @@ jobs:
       - name: Get previoulsy built artifacts win64
         uses: actions/download-artifact@v3
         with:
-          name: package-mingw64
+          name: package-windows-2022
       - name: Get previoulsy built artifacts macos
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,17 +16,30 @@ env:
 
 
 jobs:
-  build_linux:
+  build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3
-      - name: Build
+      - name: Build on Linux
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           make
+          echo Build Complete
+      - name: Build on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make"
+          echo Build Complete
+      - name: Build on Mac
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install make # need gnumake
+          gmake
           echo Build Complete
       - name: Archive toolchain
         uses: actions/upload-artifact@v3
@@ -45,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
-    needs: build_linux
+    needs: build
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3
@@ -62,54 +75,54 @@ jobs:
           make test
           echo Test Complete
 
-  build_mac:
-    strategy:
-      matrix:
-        os: [macos-11, macos-12]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Check out code from the repository
-        uses: actions/checkout@v3
-      - name: Build
-        run: |
-          brew install make # need gnumake
-          gmake
-          echo Build Complete
-      - name: Archive toolchain
-        uses: actions/upload-artifact@v3
-        with:
-          name: toolchain-${{ matrix.os }}
-          path: |
-            bin
-            examples/**/*.iso
-            examples/**/*.pce
-            examples/**/*.sgx
-          if-no-files-found: error
-
-  build_msys2_windows_2022:
-    runs-on: windows-2022
-    steps:
-      - name: Check out code from the repository
-        uses: actions/checkout@v3
-      - name: Build
-        run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make"
-          echo Build Complete
-      - name: Archive toolchain
-        uses: actions/upload-artifact@v3
-        with:
-          name: toolchain-mingw64
-          path: |
-            bin
-            examples/**/*.iso
-            examples/**/*.pce
-            examples/**/*.sgx
-          if-no-files-found: error
+  #build_mac:
+  #  strategy:
+  #    matrix:
+  #      os: [macos-11, macos-12]
+  #  runs-on: ${{ matrix.os }}
+  #  steps:
+  #    - name: Check out code from the repository
+  #      uses: actions/checkout@v3
+  #    - name: Build
+  #      run: |
+  #        brew install make # need gnumake
+  #        gmake
+  #        echo Build Complete
+  #    - name: Archive toolchain
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: toolchain-${{ matrix.os }}
+  #        path: |
+  #          bin
+  #          examples/**/*.iso
+  #          examples/**/*.pce
+  #          examples/**/*.sgx
+  #        if-no-files-found: error
+  #
+  #build_msys2_windows_2022:
+  #  runs-on: windows-2022
+  #  steps:
+  #    - name: Check out code from the repository
+  #      uses: actions/checkout@v3
+  #    - name: Build
+  #      run: |
+  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
+  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make"
+  #        echo Build Complete
+  #    - name: Archive toolchain
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: toolchain-mingw64
+  #        path: |
+  #          bin
+  #          examples/**/*.iso
+  #          examples/**/*.pce
+  #          examples/**/*.sgx
+  #        if-no-files-found: error
 
   package_msys2_windows_2022:
     runs-on: windows-2022
-    needs: build_msys2_windows_2022
+    needs: build
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3
@@ -134,7 +147,7 @@ jobs:
 
   package_macos_12:
     runs-on: macos-12
-    needs: build_mac
+    needs: build
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Archive package
         uses: actions/upload-artifact@v3
         with:
-          name: package-mingw64
+          name: package-windows-2022
           path: |
             *.zip
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,10 @@ jobs:
             src/huc/huc
             tgemu/tgemu
 
-  test_linux:
+  test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2022]
     runs-on: ${{ matrix.os }}
     needs: build
     steps:
@@ -66,14 +66,32 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: toolchain-${{ matrix.os }}
-      - name: Test
+      - name: Restore Execute Flags
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
           chmod +x bin/* # Github Action artifacts don't keep exec flags https://github.com/actions/upload-artifact#permission-loss'
           chmod +x src/huc/huc
           chmod +x tgemu/tgemu
+      - name: Run tests on Linux
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
           make check
           make test
           echo Test Complete
+      - name: Run tests on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make check"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make test"
+          echo Build Complete
+      - name: Run tests on Mac
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install make # need gnumake
+          gmake check
+          gmake test
+          echo Build Complete
 
   #build_mac:
   #  strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
 
   publish_package:
     runs-on: ubuntu-latest
-    needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04, test]
+    needs: [package, test]
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
             examples/**/*.iso
             examples/**/*.pce
             examples/**/*.sgx
-            src/huc/huc
             tgemu/tgemu
 
   test:
@@ -138,8 +137,11 @@ jobs:
   #          examples/**/*.sgx
   #        if-no-files-found: error
 
-  package_msys2_windows_2022:
-    runs-on: windows-2022
+  package:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12, windows-2022]
+    runs-on: ${{ matrix.os }}
     needs: build
     steps:
       - name: Check out code from the repository
@@ -147,33 +149,20 @@ jobs:
       - name: Get previoulsy built artifacts
         uses: actions/download-artifact@v3
         with:
-          name: toolchain-windows-2022
-      - name: Package
+          name: toolchain-${{ matrix.os }}
+      - name: Package ${{ matrix.os }}
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S mingw-w64-x86_64-binutils make git zip --noconfirm"
+          make package
+          echo Package Complete
+      - name: Package ${{ matrix.os }}
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S  make git zip --noconfirm"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make package"
           echo Package Complete
-        # https://github.com/pyTooling/Actions/tree/main/releaser
-        # need to use composite on windows, since docker isn't available
-      - name: Archive package
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-windows-2022
-          path: |
-            *.zip
-          if-no-files-found: error
-
-  package_macos_12:
-    runs-on: macos-12
-    needs: build
-    steps:
-      - name: Check out code from the repository
-        uses: actions/checkout@v3
-      - name: Get previoulsy built artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: toolchain-macos-12
-      - name: Package
+      - name: Package ${{ matrix.os }}
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew install make # need gnumake
           gmake package
@@ -181,32 +170,80 @@ jobs:
       - name: Archive package
         uses: actions/upload-artifact@v3
         with:
-          name: package-macos-12
+          name: package-${{ matrix.os }}
           path: |
             *.zip
           if-no-files-found: error
 
-  package_ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    needs: build
-    steps:
-      - name: Check out code from the repository
-        uses: actions/checkout@v3
-      - name: Get previoulsy built artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: toolchain-ubuntu-20.04
-      - name: Package
-        run: |
-          make package
-          echo Package Complete
-      - name: Archive package
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-ubuntu-20.04
-          path: |
-            *.zip
-          if-no-files-found: error
+  #package_msys2_windows_2022:
+  #  runs-on: windows-2022
+  #  needs: build
+  #  steps:
+  #    - name: Check out code from the repository
+  #      uses: actions/checkout@v3
+  #    - name: Get previoulsy built artifacts
+  #      uses: actions/download-artifact@v3
+  #      with:
+  #        name: toolchain-windows-2022
+  #    - name: Package
+  #      run: |
+  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S mingw-w64-x86_64-binutils make git zip --noconfirm"
+  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make package"
+  #        echo Package Complete
+  #      # https://github.com/pyTooling/Actions/tree/main/releaser
+  #      # need to use composite on windows, since docker isn't available
+  #    - name: Archive package
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: package-windows-2022
+  #        path: |
+  #          *.zip
+  #        if-no-files-found: error
+
+  #package_macos_12:
+  #  runs-on: macos-12
+  #  needs: build
+  #  steps:
+  #    - name: Check out code from the repository
+  #      uses: actions/checkout@v3
+  #    - name: Get previoulsy built artifacts
+  #      uses: actions/download-artifact@v3
+  #      with:
+  #        name: toolchain-macos-12
+  #    - name: Package
+  #      run: |
+  #        brew install make # need gnumake
+  #        gmake package
+  #        echo Package Complete
+  #    - name: Archive package
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: package-macos-12
+  #        path: |
+  #          *.zip
+  #        if-no-files-found: error
+  #
+  #package_ubuntu-20-04:
+  #  runs-on: ubuntu-20.04
+  #  needs: build
+  #  steps:
+  #    - name: Check out code from the repository
+  #      uses: actions/checkout@v3
+  #    - name: Get previoulsy built artifacts
+  #      uses: actions/download-artifact@v3
+  #      with:
+  #        name: toolchain-ubuntu-20.04
+  #    - name: Package
+  #      run: |
+  #        make package
+  #        echo Package Complete
+  #    - name: Archive package
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: package-ubuntu-20.04
+  #        path: |
+  #          *.zip
+  #        if-no-files-found: error
 
   publish_package:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
           chmod +x bin/* # Github Action artifacts don't keep exec flags https://github.com/actions/upload-artifact#permission-loss'
-          chmod +x src/huc/huc
           chmod +x tgemu/tgemu
       - name: Run tests on Linux
         if: startsWith(matrix.os, 'ubuntu')
@@ -158,7 +157,7 @@ jobs:
       - name: Package ${{ matrix.os }}
         if: startsWith(matrix.os, 'windows')
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S  make git zip --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S  binutils make git zip --noconfirm"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make package"
           echo Package Complete
       - name: Package ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
   publish_package:
     runs-on: ubuntu-latest
     needs: [package, test]
-    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,51 +91,6 @@ jobs:
           gmake test
           echo Build Complete
 
-  #build_mac:
-  #  strategy:
-  #    matrix:
-  #      os: [macos-11, macos-12]
-  #  runs-on: ${{ matrix.os }}
-  #  steps:
-  #    - name: Check out code from the repository
-  #      uses: actions/checkout@v3
-  #    - name: Build
-  #      run: |
-  #        brew install make # need gnumake
-  #        gmake
-  #        echo Build Complete
-  #    - name: Archive toolchain
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: toolchain-${{ matrix.os }}
-  #        path: |
-  #          bin
-  #          examples/**/*.iso
-  #          examples/**/*.pce
-  #          examples/**/*.sgx
-  #        if-no-files-found: error
-  #
-  #build_msys2_windows_2022:
-  #  runs-on: windows-2022
-  #  steps:
-  #    - name: Check out code from the repository
-  #      uses: actions/checkout@v3
-  #    - name: Build
-  #      run: |
-  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
-  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make"
-  #        echo Build Complete
-  #    - name: Archive toolchain
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: toolchain-mingw64
-  #        path: |
-  #          bin
-  #          examples/**/*.iso
-  #          examples/**/*.pce
-  #          examples/**/*.sgx
-  #        if-no-files-found: error
-
   package:
     strategy:
       matrix:
@@ -173,76 +128,6 @@ jobs:
           path: |
             *.zip
           if-no-files-found: error
-
-  #package_msys2_windows_2022:
-  #  runs-on: windows-2022
-  #  needs: build
-  #  steps:
-  #    - name: Check out code from the repository
-  #      uses: actions/checkout@v3
-  #    - name: Get previoulsy built artifacts
-  #      uses: actions/download-artifact@v3
-  #      with:
-  #        name: toolchain-windows-2022
-  #    - name: Package
-  #      run: |
-  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S mingw-w64-x86_64-binutils make git zip --noconfirm"
-  #        ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make package"
-  #        echo Package Complete
-  #      # https://github.com/pyTooling/Actions/tree/main/releaser
-  #      # need to use composite on windows, since docker isn't available
-  #    - name: Archive package
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: package-windows-2022
-  #        path: |
-  #          *.zip
-  #        if-no-files-found: error
-
-  #package_macos_12:
-  #  runs-on: macos-12
-  #  needs: build
-  #  steps:
-  #    - name: Check out code from the repository
-  #      uses: actions/checkout@v3
-  #    - name: Get previoulsy built artifacts
-  #      uses: actions/download-artifact@v3
-  #      with:
-  #        name: toolchain-macos-12
-  #    - name: Package
-  #      run: |
-  #        brew install make # need gnumake
-  #        gmake package
-  #        echo Package Complete
-  #    - name: Archive package
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: package-macos-12
-  #        path: |
-  #          *.zip
-  #        if-no-files-found: error
-  #
-  #package_ubuntu-20-04:
-  #  runs-on: ubuntu-20.04
-  #  needs: build
-  #  steps:
-  #    - name: Check out code from the repository
-  #      uses: actions/checkout@v3
-  #    - name: Get previoulsy built artifacts
-  #      uses: actions/download-artifact@v3
-  #      with:
-  #        name: toolchain-ubuntu-20.04
-  #    - name: Package
-  #      run: |
-  #        make package
-  #        echo Package Complete
-  #    - name: Archive package
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: package-ubuntu-20.04
-  #        path: |
-  #          *.zip
-  #        if-no-files-found: error
 
   publish_package:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build on Windows
         if: startsWith(matrix.os, 'windows')
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S binutils make mingw-w64-x86_64-gcc git --noconfirm"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make"
           echo Build Complete
       - name: Build on Mac
@@ -88,7 +88,7 @@ jobs:
       - name: Run tests on Mac
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install make # need gnumake
+          brew install make md5sha1sum # need gnumake and md5sum to run make check
           gmake check
           gmake test
           echo Build Complete
@@ -210,7 +210,7 @@ jobs:
 
   publish_package:
     runs-on: ubuntu-latest
-    needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04]
+    needs: [package_msys2_windows_2022, package_macos_12, package_ubuntu-20-04, test]
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
   publish_package:
     runs-on: ubuntu-latest
     needs: [package, test]
-    #if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
 
   package_ubuntu-20-04:
     runs-on: ubuntu-20.04
-    needs: build_linux
+    needs: build
     steps:
       - name: Check out code from the repository
         uses: actions/checkout@v3


### PR DESCRIPTION
* Added 'make check and test' steps for all platforms.
* Reduced dependencies of packaging step on windows (only binutils is needed for strip command)
* Package and Testing stages are run in parallel
* Package publication only runs if packages and tests are green.
* Added installation of md5sha1sum  package on Mac to make the 'make check' command happy on mac (it needs md5sum)
