### PR TITLE
Activate tests on all platforms for real

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,9 @@ jobs:
     needs: build
     steps:
       - name: Check out code from the repository
-        run: |
-          git config --system core.autocrlf false
-          git config --system core.eol lf
+        #run: |
+        #  git config --system core.autocrlf false
+        #  git config --system core.eol lf
         uses: actions/checkout@v3
       - name: Get previoulsy built artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,6 @@ jobs:
     needs: build
     steps:
       - name: Check out code from the repository
-        #run: |
-        #  git config --system core.autocrlf false
-        #  git config --system core.eol lf
         uses: actions/checkout@v3
       - name: Get previoulsy built artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests on Windows
         if: startsWith(matrix.os, 'windows')
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S base-devel mingw-w64-x86_64-gcc git --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S coreutils make git --noconfirm"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make check"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make test"
           echo Build Complete

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
     needs: build
     steps:
       - name: Check out code from the repository
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
         uses: actions/checkout@v3
       - name: Get previoulsy built artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,14 +79,14 @@ jobs:
       - name: Run tests on Windows
         if: startsWith(matrix.os, 'windows')
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S coreutils make git --noconfirm"
+          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S coreutils make git dos2unix --noconfirm"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make check"
           ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make test"
           echo Build Complete
       - name: Run tests on Mac
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install make md5sha1sum # need gnumake and md5sum to run make check
+          brew install make md5sha1sum dos2unix # need gnumake and md5sum to run make check
           gmake check
           gmake test
           echo Build Complete

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Run tests on Linux
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update && sudo apt-get install -y dos2unix
           make check
           make test
           echo Test Complete

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,7 @@ install:
 	cp -pr include/huc/* /usr/include/huc/
 
 test:
-ifneq ($(shell uname -s),Linux)
-	@echo ''
-	@echo 'Note: "make test" only runs on a linux platform!'
-else
 	cd test ; ./mk
-endif
 
 check:
 	@echo ''

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 
 check:
 	@echo ''
-	md5sum --strict -c < examples/huc/checksum.txt
+	cat examples/huc/checksum.txt | tr -d '\r' | md5sum --strict -c
 
 DATE = $(shell date +%F)
 ifneq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 
 check:
 	@echo ''
-	md5sum -c < examples/huc/checksum.txt
+	md5sum --strict -c < examples/huc/checksum.txt
 
 DATE = $(shell date +%F)
 ifneq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ test:
 
 check:
 	@echo ''
-	cat examples/huc/checksum.txt | tr -d '\r' | md5sum --strict -c
+	dos2unix examples/huc/checksum.txt
+	md5sum -c < examples/huc/checksum.txt
 
 DATE = $(shell date +%F)
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
We have a false green :)

The high-level check for platform was still in place with the previous PR, so tests on Mac and Win64 weren't really run by the CI.
Sorry for missing that

* Removed platform check in make test
* Reduced requirements for testing on Win64 (no need for full gcc)
* Tried to make pd5sum more strict

Testing this change led to an interesting discovery.
on Win64, the md5sum is failing (I guess Github Actions checkout job converts endline into windows endline.)
md5sum doesn't understand the \r and fails
It fails, but the makefile still thinks it's a success, causing a false green
