### PR TITLE
Avoid false positives in 'make check' on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,12 +77,19 @@ jobs:
           make check
           make test
           echo Test Complete
+      - name: Setup Msys2
+        if: startsWith(matrix.os, 'windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: coreutils make git dos2unix
       - name: Run tests on Windows
         if: startsWith(matrix.os, 'windows')
+        shell: msys2 {0}
         run: |
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -c "pacman -S coreutils make git dos2unix --noconfirm"
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make check"
-          ${{ env.MSYS2_INSTALL_FOLDER }}\msys2_shell.cmd -mingw64 -no-start -defterm -where %CD% -c "make test"
+          make check
+          make test
           echo Build Complete
       - name: Run tests on Mac
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && sudo apt-get install -y dos2unix
-          make check
+          #make check
           make test
           echo Test Complete
       - name: Setup Msys2
@@ -95,7 +95,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install make md5sha1sum dos2unix # need gnumake and md5sum to run make check
-          gmake check
+          #gmake check
           gmake test
           echo Build Complete
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && sudo apt-get install -y dos2unix
-          #make check
+          make check
           make test
           echo Test Complete
       - name: Setup Msys2
@@ -95,7 +95,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install make md5sha1sum dos2unix # need gnumake and md5sum to run make check
-          #gmake check
+          gmake check
           gmake test
           echo Build Complete
 

--- a/examples/huc/checksum.txt
+++ b/examples/huc/checksum.txt
@@ -1,7 +1,7 @@
 # Known MD5 checksums for the compiled HuC examples
 # which can be used to check for toolchain breakage.
 #
-3f465ce25df42e348bdd420d2a245683 *examples/huc/acd/ac_test.iso
+2f465ce25df42e348bdd420d2a245683 *examples/huc/acd/ac_test.iso
 df6786bd799becd0b874a140cb420261 *examples/huc/overlay/overlay.iso
 336d03645a452a36de6bfa08c0de9f06 *examples/huc/promotion/promotion.pce
 cafa0f90b98fcdc7837efc595fdafdee *examples/huc/scroll/scroll.pce

--- a/examples/huc/checksum.txt
+++ b/examples/huc/checksum.txt
@@ -1,7 +1,7 @@
 # Known MD5 checksums for the compiled HuC examples
 # which can be used to check for toolchain breakage.
 #
-2f465ce25df42e348bdd420d2a245683 *examples/huc/acd/ac_test.iso
+3f465ce25df42e348bdd420d2a245683 *examples/huc/acd/ac_test.iso
 df6786bd799becd0b874a140cb420261 *examples/huc/overlay/overlay.iso
 336d03645a452a36de6bfa08c0de9f06 *examples/huc/promotion/promotion.pce
 cafa0f90b98fcdc7837efc595fdafdee *examples/huc/scroll/scroll.pce


### PR DESCRIPTION
tests execution is broken up into 2 calls to make
make check
make tests

If msys commands are invoked one after the other in the run statement, the default runner on windows (powershell in this case) will keep executing the commands even if one of them fails.
So if 'make check' fails, execution will continue, and flow result is in fact determined by the status of the last command executed.

Change:
make commands are now run natively in the msys shell once setup with the appropriate parameters. (using the official github action for sys)
Since msys shell stops at first failures, we get a real red if 'make check' fails
It's also supposed to use the github cache to speedup setup, but speed gains weren't that obvious
